### PR TITLE
Fix the ttnctl cert creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cat discovery/server.cert > broker/ca.cert
 cat discovery/server.cert > handler/ca.cert
 cat discovery/server.cert > bridge/ca.cert
 cat networkserver/server.cert > broker/networkserver.cert
-cat discovery/server.cert > ~/.ttnctl/ca.cert
+cat discovery/server.cert > ttnctl/ca.cert
 ```
 
 	


### PR DESCRIPTION
The `~/.ttnctl/ca.cert` directory doesn't exist. Or if it does, it's because it has been created not in this instructrion set.